### PR TITLE
tolerance: expect_identical => expect_equal

### DIFF
--- a/tests/testthat/test_verbs.R
+++ b/tests/testthat/test_verbs.R
@@ -79,8 +79,8 @@ mt_dt = as.data.table(mtcars)
 res = dt_summarize(mtcars, (new_var1) := eval(expr1), (new_var2) := eval(expr2), by = am)
 res2 = dt_summarize(mt_dt, (new_var1) := eval(expr1), (new_var2) := eval(expr2), by = am)
 res3 = mt_dt[, list(agg = mean(mpg), agg2 = mean(hp)), by = am]
-expect_identical(res3, res)
-expect_identical(res3, res2)
+expect_equal(res3, res)
+expect_equal(res3, res2)
 
 
 

--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -166,5 +166,5 @@ new_var2 = "agg2"
 res = take(mtcars, (new_var) := eval(expr1), (new_var2) := eval(expr2), by = am)
 res2 = take(mt_dt, (new_var) := eval(expr1), (new_var2) := eval(expr2), by = am)
 res3 = mt_dt[, list(agg = mean(mpg), agg2 = mean(hp)), by = am]
-expect_identical(res3, res)
-expect_identical(res3, res2)
+expect_equal(res3, res)
+expect_equal(res3, res2)


### PR DESCRIPTION
Hi Gregory,

Please could you update `maditr` on CRAN to relax these `expect_identical` to `expect_equal`. There is a very small within tolerance difference in v1.12.0 about to go to CRAN at which point `maditr` will begin to fail with error on CRAN.

Best, Matt
