### PR TITLE
coalesce uses ... instead of fun copy

### DIFF
--- a/R/coalesce.R
+++ b/R/coalesce.R
@@ -15,4 +15,4 @@
 #' z = c(NA, NA, 3, 4, 5)
 #' coalesce(y, z)
 #' @export
-coalesce = data.table::fcoalesce
+coalesce = function(...)data.table::fcoalesce(...)


### PR DESCRIPTION
Hi @gdemin 
While checking your new CRAN version of maditr, we noticed a new warning https://github.com/Rdatatable/data.table/issues/7278

This PR makes that warning go away, by changing the definition of coalesce.

Can you please merge and then submit an update to CRAN in the next few weeks?

CRAN requires data.table to be compatible with all packages that depend on it (like maditr), so merging this PR will help us release the next version of data.table.

Thanks!